### PR TITLE
Add NodeJS TypeScript devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,1 @@
+{"image":"mcr.microsoft.com/devcontainers/typescript-node:20-bookworm"}


### PR DESCRIPTION
Use the [Node.js & TypeScript devcontainer][1] when opening the repo in a remote container or GitHub Codespace.

[1]: https://github.com/devcontainers/images/tree/main/src/typescript-node